### PR TITLE
feat: negotiate A2A extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,44 @@ As you see, it's pretty easy from the point of view of the developer using your 
 > In Pydantic AI 1.x, `Agent.to_a2a()` continues to work but emits a deprecation
 > warning pointing here. It will be removed in Pydantic AI v2.
 
+## Extensions
+
+An [extension](https://a2a-protocol.org/latest/topics/extensions/) is a capability negotiated by URI on top of the
+core protocol. The agent declares the ones it supports in its card, a client asks for some of them in the
+`A2A-Extensions` request header, and the agent answers on the same header with the ones it activated.
+
+Declare them on the application (or pass `extensions=` to `agent_to_a2a`):
+
+```python
+from fasta2a import AgentExtension, FastA2A
+
+app = FastA2A(
+    storage=storage,
+    broker=broker,
+    extensions=[
+        AgentExtension(uri='https://example.com/ext/citations/v1', description='Cites its sources'),
+        AgentExtension(uri='https://example.com/ext/trace/v1', required=True),
+    ],
+)
+```
+
+For every request, **FastA2A** activates the requested extensions it supports — a URI it never declared is
+ignored and not echoed back, which is how the client learns that — and puts the activated list in the message
+`metadata`, so a `Worker` can read what was agreed for the task it is running:
+
+```python
+from fasta2a import activated_extensions
+
+
+class MyWorker(Worker[Context]):
+    async def run_task(self, params: TaskSendParams) -> None:
+        if 'https://example.com/ext/citations/v1' in activated_extensions(params):
+            ...  # add citation parts to the artifacts
+```
+
+A `message/send` or `message/stream` that leaves a `required` extension inactive is refused with a
+`-32600` error whose `data.missing_required_extensions` names it, before any task is created.
+
 ## Design
 
 **FastA2A** is built on top of [Starlette](https://www.starlette.io/), which means it's fully compatible

--- a/fasta2a/__init__.py
+++ b/fasta2a/__init__.py
@@ -6,12 +6,12 @@ from .storage import Storage
 from .worker import Worker
 
 __all__ = [
+    'A2A_EXTENSIONS_HEADER',
+    'AgentExtension',
+    'Broker',
     'FastA2A',
     'Skill',
     'Storage',
-    'Broker',
     'Worker',
-    'AgentExtension',
-    'A2A_EXTENSIONS_HEADER',
     'activated_extensions',
 ]

--- a/fasta2a/__init__.py
+++ b/fasta2a/__init__.py
@@ -1,7 +1,17 @@
 from .applications import FastA2A
 from .broker import Broker
-from .schema import Skill
+from .extensions import A2A_EXTENSIONS_HEADER, activated_extensions
+from .schema import AgentExtension, Skill
 from .storage import Storage
 from .worker import Worker
 
-__all__ = ['FastA2A', 'Skill', 'Storage', 'Broker', 'Worker']
+__all__ = [
+    'FastA2A',
+    'Skill',
+    'Storage',
+    'Broker',
+    'Worker',
+    'AgentExtension',
+    'A2A_EXTENSIONS_HEADER',
+    'activated_extensions',
+]

--- a/fasta2a/applications.py
+++ b/fasta2a/applications.py
@@ -168,7 +168,9 @@ class FastA2A(Starlette):
         # metadata so the worker sees what was agreed.
         activated = self._negotiate_extensions(request)
         headers = {A2A_EXTENSIONS_HEADER: format_extensions_header(activated)} if activated else {}
-        if a2a_request['method'] in ('message/send', 'message/stream'):
+        # Two comparisons rather than `in`: that is what narrows the request
+        # union to the two whose params carry a message and its metadata.
+        if a2a_request['method'] == 'message/send' or a2a_request['method'] == 'message/stream':
             missing = missing_required_extensions(self.extensions, activated)
             if missing:
                 error_response = SendMessageResponse(

--- a/fasta2a/applications.py
+++ b/fasta2a/applications.py
@@ -15,12 +15,23 @@ from starlette.routing import Route
 from starlette.types import ExceptionHandler, Lifespan, Receive, Scope, Send
 
 from .broker import Broker
+from .extensions import (
+    A2A_EXTENSIONS_HEADER,
+    ACTIVATED_EXTENSIONS_KEY,
+    format_extensions_header,
+    missing_required_extensions,
+    parse_extensions_header,
+    select_activated_extensions,
+)
 from .schema import (
     A2AResponse,
     AgentCapabilities,
     AgentCard,
+    AgentExtension,
     AgentInterface,
     AgentProvider,
+    InvalidRequestError,
+    SendMessageResponse,
     Skill,
     a2a_request_ta,
     a2a_response_ta,
@@ -45,6 +56,7 @@ class FastA2A(Starlette):
         description: str | None = None,
         provider: AgentProvider | None = None,
         skills: list[Skill] | None = None,
+        extensions: list[AgentExtension] | None = None,
         docs_url: str | None = '/docs',
         # Starlette
         debug: bool = False,
@@ -70,6 +82,7 @@ class FastA2A(Starlette):
         self.description = description
         self.provider = provider
         self.skills = skills or []
+        self.extensions = extensions or []
         self.docs_url = docs_url
         # NOTE: For now, I don't think there's any reason to support any other input/output modes.
         self.default_input_modes = ['application/json']
@@ -104,12 +117,23 @@ class FastA2A(Starlette):
                 skills=self.skills,
                 default_input_modes=self.default_input_modes,
                 default_output_modes=self.default_output_modes,
-                capabilities=AgentCapabilities(streaming=True, push_notifications=False),
+                capabilities=self._capabilities(),
             )
             if self.provider is not None:
                 agent_card['provider'] = self.provider
             self._agent_card_json_schema = agent_card_ta.dump_json(agent_card, by_alias=True)
         return Response(content=self._agent_card_json_schema, media_type='application/json')
+
+    def _capabilities(self) -> AgentCapabilities:
+        capabilities = AgentCapabilities(streaming=True, push_notifications=False)
+        if self.extensions:
+            capabilities['extensions'] = list(self.extensions)
+        return capabilities
+
+    def _negotiate_extensions(self, request: Request) -> list[str]:
+        """The extensions this request activates: the ones it asked for that the agent supports."""
+        requested = parse_extensions_header(request.headers.get(A2A_EXTENSIONS_HEADER))
+        return select_activated_extensions(self.extensions, requested)
 
     async def _docs_endpoint(self, request: Request) -> Response:
         """Serve the documentation interface."""
@@ -136,6 +160,36 @@ class FastA2A(Starlette):
         data = await request.body()
         a2a_request = a2a_request_ta.validate_json(data)
 
+        # Extensions are negotiated per request: the client names the ones it
+        # wants in the `A2A-Extensions` header, the agent activates those it
+        # supports and says which in the same header on its response. A message
+        # that leaves a *required* extension inactive is refused before a task
+        # is created for it, and the activated list rides in the message
+        # metadata so the worker sees what was agreed.
+        activated = self._negotiate_extensions(request)
+        headers = {A2A_EXTENSIONS_HEADER: format_extensions_header(activated)} if activated else {}
+        if a2a_request['method'] in ('message/send', 'message/stream'):
+            missing = missing_required_extensions(self.extensions, activated)
+            if missing:
+                error_response = SendMessageResponse(
+                    jsonrpc='2.0',
+                    id=a2a_request['id'],
+                    error=InvalidRequestError(
+                        code=-32600,
+                        message='Request payload validation error',
+                        data={'missing_required_extensions': missing},
+                    ),
+                )
+                return Response(
+                    content=a2a_response_ta.dump_json(error_response, by_alias=True),
+                    media_type='application/json',
+                    headers=headers,
+                )
+            if activated:
+                metadata = dict(a2a_request['params'].get('metadata') or {})
+                metadata[ACTIVATED_EXTENSIONS_KEY] = activated
+                a2a_request['params']['metadata'] = metadata
+
         jsonrpc_response: A2AResponse
         if a2a_request['method'] == 'message/send':
             jsonrpc_response = await self.task_manager.send_message(a2a_request)
@@ -157,16 +211,20 @@ class FastA2A(Starlette):
             return StreamingResponse(
                 self.task_manager.stream_message(a2a_request),
                 media_type='text/event-stream',
+                headers=headers,
             )
         elif a2a_request['method'] == 'tasks/resubscribe':
             return StreamingResponse(
                 self.task_manager.resubscribe_task(a2a_request),
                 media_type='text/event-stream',
+                headers=headers,
             )
         else:
             raise NotImplementedError(f'Method {a2a_request["method"]} not implemented.')
         return Response(
-            content=a2a_response_ta.dump_json(jsonrpc_response, by_alias=True), media_type='application/json'
+            content=a2a_response_ta.dump_json(jsonrpc_response, by_alias=True),
+            media_type='application/json',
+            headers=headers,
         )
 
 

--- a/fasta2a/extensions.py
+++ b/fasta2a/extensions.py
@@ -14,7 +14,7 @@ negotiating; a `Worker` reads the outcome with `activated_extensions`.
 from __future__ import annotations as _annotations
 
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, cast
 
 from .schema import AgentExtension
 
@@ -79,8 +79,10 @@ def activated_extensions(params: Mapping[str, Any]) -> list[str]:
     `FastA2A` records them — so a worker asks this of the params it was handed
     and gets what the client and the agent agreed on for that message.
     """
-    metadata = params.get('metadata') or {}
-    value = metadata.get(ACTIVATED_EXTENSIONS_KEY)
+    metadata = params.get('metadata')
+    if not isinstance(metadata, Mapping):
+        return []
+    value: object = cast('Mapping[str, object]', metadata).get(ACTIVATED_EXTENSIONS_KEY)
     if not isinstance(value, list):
         return []
-    return [str(uri) for uri in value]
+    return [str(uri) for uri in cast('list[object]', value)]

--- a/fasta2a/extensions.py
+++ b/fasta2a/extensions.py
@@ -1,0 +1,86 @@
+"""A2A protocol extensions: what an agent supports, and what a request activated.
+
+An extension is a capability negotiated by URI, on top of the core protocol
+(https://a2a-protocol.org/latest/topics/extensions/). The agent lists the
+ones it supports in its card; a client asks for some of them in the
+``A2A-Extensions`` request header; the agent activates the ones it knows,
+tells the client which in the same header on the response, and makes the list
+available to whatever handles the task.
+
+This module is the vocabulary for that exchange. `FastA2A` does the
+negotiating; a `Worker` reads the outcome with `activated_extensions`.
+"""
+
+from __future__ import annotations as _annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .schema import AgentExtension
+
+__all__ = (
+    'A2A_EXTENSIONS_HEADER',
+    'ACTIVATED_EXTENSIONS_KEY',
+    'activated_extensions',
+    'format_extensions_header',
+    'missing_required_extensions',
+    'parse_extensions_header',
+    'select_activated_extensions',
+)
+
+A2A_EXTENSIONS_HEADER = 'A2A-Extensions'
+"""The header a client activates extensions with, and the agent answers on."""
+
+ACTIVATED_EXTENSIONS_KEY = 'a2a.activated_extensions'
+"""Where the activated URIs travel in the request's ``metadata``, down to the worker."""
+
+
+def parse_extensions_header(value: str | None) -> list[str]:
+    """The extension URIs an ``A2A-Extensions`` header names.
+
+    Comma-separated; whitespace around a URI is dropped, so is a repeated one,
+    and the order the client wrote them in is kept.
+    """
+    if not value:
+        return []
+    uris: list[str] = []
+    for raw in value.split(','):
+        uri = raw.strip()
+        if uri and uri not in uris:
+            uris.append(uri)
+    return uris
+
+
+def format_extensions_header(uris: Iterable[str]) -> str:
+    """The header value for a list of URIs."""
+    return ', '.join(uris)
+
+
+def select_activated_extensions(supported: Iterable[AgentExtension], requested: Iterable[str]) -> list[str]:
+    """Of the URIs a client asked for, the ones this agent supports — in the client's order.
+
+    A URI the agent never declared is not activated and not echoed back, which
+    is how the client learns it was ignored.
+    """
+    known = {extension['uri'] for extension in supported}
+    return [uri for uri in requested if uri in known]
+
+
+def missing_required_extensions(supported: Iterable[AgentExtension], activated: Iterable[str]) -> list[str]:
+    """The extensions this agent marks ``required`` that the client did not activate."""
+    active = set(activated)
+    return [extension['uri'] for extension in supported if extension.get('required') and extension['uri'] not in active]
+
+
+def activated_extensions(params: Mapping[str, Any]) -> list[str]:
+    """The extension URIs activated for a request or a task.
+
+    Read from the ``metadata`` of `MessageSendParams` or `TaskSendParams`, where
+    `FastA2A` records them — so a worker asks this of the params it was handed
+    and gets what the client and the agent agreed on for that message.
+    """
+    metadata = params.get('metadata') or {}
+    value = metadata.get(ACTIVATED_EXTENSIONS_KEY)
+    if not isinstance(value, list):
+        return []
+    return [str(uri) for uri in value]

--- a/fasta2a/pydantic_ai/_bridge.py
+++ b/fasta2a/pydantic_ai/_bridge.py
@@ -43,6 +43,7 @@ from starlette.types import ExceptionHandler, Lifespan
 from fasta2a.applications import FastA2A
 from fasta2a.broker import Broker, InMemoryBroker
 from fasta2a.schema import (
+    AgentExtension,
     AgentProvider,
     Artifact,
     Message,
@@ -78,6 +79,7 @@ def agent_to_a2a(
     description: str | None = None,
     provider: AgentProvider | None = None,
     skills: list[Skill] | None = None,
+    extensions: list[AgentExtension] | None = None,
     debug: bool = False,
     routes: Sequence[Route] | None = None,
     middleware: Sequence[Middleware] | None = None,
@@ -100,6 +102,7 @@ def agent_to_a2a(
         description=description,
         provider=provider,
         skills=skills,
+        extensions=extensions,
         debug=debug,
         routes=routes,
         middleware=middleware,

--- a/fasta2a/task_manager.py
+++ b/fasta2a/task_manager.py
@@ -137,6 +137,9 @@ class TaskManager:
         history_length = config.get('history_length')
         if history_length is not None:
             broker_params['history_length'] = history_length
+        metadata = request['params'].get('metadata')
+        if metadata:
+            broker_params['metadata'] = metadata
 
         await self.broker.run_task(broker_params)
         result = SendMessageResult(task=task)
@@ -183,6 +186,9 @@ class TaskManager:
         history_length = config.get('history_length')
         if history_length is not None:
             broker_params['history_length'] = history_length
+        metadata = request['params'].get('metadata')
+        if metadata:
+            broker_params['metadata'] = metadata
 
         async with self.broker.event_bus.subscribe(task_id) as receive_stream:
             await self.broker.run_task(broker_params)

--- a/scripts/check
+++ b/scripts/check
@@ -4,8 +4,8 @@ set -x
 
 SOURCE_FILES="fasta2a tests"
 
-uvx ruff format --check --diff $SOURCE_FILES
-uvx ruff check $SOURCE_FILES
+uv run ruff format --check --diff $SOURCE_FILES
+uv run ruff check $SOURCE_FILES
 uv run pyright
 uvx check-sdist
 uv lock

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -124,6 +124,8 @@ def test_activation_is_the_intersection_in_the_clients_order():
 
 def test_activated_extensions_reads_the_metadata_key():
     assert activated_extensions({}) == []
+    assert activated_extensions({'metadata': None}) == []
+    assert activated_extensions({'metadata': 'not-a-mapping'}) == []
     assert activated_extensions({'metadata': {ACTIVATED_EXTENSIONS_KEY: 'not-a-list'}}) == []
     assert activated_extensions({'metadata': {ACTIVATED_EXTENSIONS_KEY: [TRACE]}}) == [TRACE]
 
@@ -185,13 +187,15 @@ async def test_a_required_extension_left_inactive_is_refused_before_a_task_exist
 
 async def test_a_stream_echoes_the_activated_extensions():
     app, worker = build_app([AgentExtension(uri=TRACE)])
-    async with client_for(app) as client:
-        async with client.stream(
+    async with (
+        client_for(app) as client,
+        client.stream(
             'POST', '/', json=send_message_request('message/stream'), headers={A2A_EXTENSIONS_HEADER: TRACE}
-        ) as response:
-            assert response.status_code == 200
-            assert response.headers[A2A_EXTENSIONS_HEADER] == TRACE
-            events = [line async for line in response.aiter_lines() if line.startswith('data: ')]
+        ) as response,
+    ):
+        assert response.status_code == 200
+        assert response.headers[A2A_EXTENSIONS_HEADER] == TRACE
+        events = [line async for line in response.aiter_lines() if line.startswith('data: ')]
     assert events, 'the stream sent nothing'
     assert worker.seen == [[TRACE]]
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,216 @@
+"""Extensions: what the card declares, what a request activates, and what the worker sees."""
+
+from __future__ import annotations as _annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from fasta2a import A2A_EXTENSIONS_HEADER, AgentExtension, FastA2A, activated_extensions
+from fasta2a.broker import InMemoryBroker
+from fasta2a.extensions import (
+    ACTIVATED_EXTENSIONS_KEY,
+    format_extensions_header,
+    missing_required_extensions,
+    parse_extensions_header,
+    select_activated_extensions,
+)
+from fasta2a.schema import (
+    Artifact,
+    Message,
+    StreamResponse,
+    TaskIdParams,
+    TaskSendParams,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from fasta2a.storage import InMemoryStorage
+from fasta2a.worker import Worker
+
+pytestmark = pytest.mark.anyio
+
+TRACE = 'urn:example:trace'
+CITATIONS = 'urn:example:citations'
+UNKNOWN = 'urn:example:nobody-declared-this'
+
+
+class RecordingWorker(Worker[Any]):
+    """Echoes the message back as an artifact and records the extensions each task ran with."""
+
+    def __init__(self, broker: InMemoryBroker, storage: InMemoryStorage[Any]) -> None:
+        super().__init__(broker=broker, storage=storage)
+        self.seen: list[list[str]] = []
+
+    async def run_task(self, params: TaskSendParams) -> None:
+        self.seen.append(activated_extensions(params))
+        await self.storage.update_task(params['id'], state='working')
+        artifact = Artifact(artifact_id=str(uuid.uuid4()), parts=params['message']['parts'])
+        await self.storage.update_task(params['id'], state='completed', new_artifacts=[artifact])
+        # A stream ends when its worker says so: the final status, then the bus closed.
+        await self.broker.event_bus.emit(
+            params['id'],
+            StreamResponse(
+                status_update=TaskStatusUpdateEvent(
+                    task_id=params['id'], context_id=params['context_id'], status=TaskStatus(state='completed')
+                )
+            ),
+        )
+        await self.broker.event_bus.close(params['id'])
+
+    async def cancel_task(self, params: TaskIdParams) -> None:
+        pass
+
+    def build_message_history(self, history: list[Message]) -> list[Any]:
+        return []
+
+    def build_artifacts(self, result: Any) -> list[Artifact]:
+        return []
+
+
+def build_app(extensions: list[AgentExtension] | None) -> tuple[FastA2A, RecordingWorker]:
+    storage: InMemoryStorage[Any] = InMemoryStorage()
+    broker = InMemoryBroker()
+    worker = RecordingWorker(broker=broker, storage=storage)
+
+    @asynccontextmanager
+    async def lifespan(app: FastA2A) -> AsyncIterator[None]:
+        async with app.task_manager, worker.run():
+            yield
+
+    return FastA2A(storage=storage, broker=broker, extensions=extensions, lifespan=lifespan), worker
+
+
+@asynccontextmanager
+async def client_for(app: FastA2A) -> AsyncIterator[httpx.AsyncClient]:
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url='http://testclient') as client:
+            yield client
+
+
+def send_message_request(method: str = 'message/send') -> dict[str, Any]:
+    return {
+        'jsonrpc': '2.0',
+        'id': str(uuid.uuid4()),
+        'method': method,
+        'params': {
+            'message': {
+                'role': 'user',
+                'parts': [{'kind': 'text', 'text': 'hello'}],
+                'kind': 'message',
+                'messageId': str(uuid.uuid4()),
+            }
+        },
+    }
+
+
+def test_header_parsing_drops_blanks_and_repeats_and_keeps_order():
+    assert parse_extensions_header(None) == []
+    assert parse_extensions_header('') == []
+    assert parse_extensions_header(f' {CITATIONS} ,{TRACE},, {CITATIONS}') == [CITATIONS, TRACE]
+    assert format_extensions_header([CITATIONS, TRACE]) == f'{CITATIONS}, {TRACE}'
+
+
+def test_activation_is_the_intersection_in_the_clients_order():
+    supported = [AgentExtension(uri=TRACE), AgentExtension(uri=CITATIONS, required=True)]
+    assert select_activated_extensions(supported, [UNKNOWN, CITATIONS, TRACE]) == [CITATIONS, TRACE]
+    assert missing_required_extensions(supported, [TRACE]) == [CITATIONS]
+    assert missing_required_extensions(supported, [TRACE, CITATIONS]) == []
+
+
+def test_activated_extensions_reads_the_metadata_key():
+    assert activated_extensions({}) == []
+    assert activated_extensions({'metadata': {ACTIVATED_EXTENSIONS_KEY: 'not-a-list'}}) == []
+    assert activated_extensions({'metadata': {ACTIVATED_EXTENSIONS_KEY: [TRACE]}}) == [TRACE]
+
+
+async def test_agent_card_declares_the_extensions():
+    app, _ = build_app([AgentExtension(uri=TRACE, description='Emits a trace artifact'), AgentExtension(uri=CITATIONS)])
+    async with client_for(app) as client:
+        response = await client.get('/.well-known/agent-card.json')
+    assert response.status_code == 200
+    assert response.json()['capabilities']['extensions'] == [
+        {'uri': TRACE, 'description': 'Emits a trace artifact'},
+        {'uri': CITATIONS},
+    ]
+
+
+async def test_agent_card_without_extensions_declares_none():
+    app, _ = build_app(None)
+    async with client_for(app) as client:
+        response = await client.get('/.well-known/agent-card.json')
+    assert 'extensions' not in response.json()['capabilities']
+
+
+async def test_a_request_activates_supported_extensions_and_the_worker_sees_them():
+    app, worker = build_app([AgentExtension(uri=TRACE), AgentExtension(uri=CITATIONS)])
+    async with client_for(app) as client:
+        response = await client.post(
+            '/', json=send_message_request(), headers={A2A_EXTENSIONS_HEADER: f'{UNKNOWN}, {CITATIONS}'}
+        )
+    assert response.status_code == 200
+    assert 'result' in response.json()
+    # Echoed back without the one the agent never declared: that is how the client learns it was ignored.
+    assert response.headers[A2A_EXTENSIONS_HEADER] == CITATIONS
+    assert worker.seen == [[CITATIONS]]
+
+
+async def test_no_header_activates_nothing():
+    app, worker = build_app([AgentExtension(uri=TRACE)])
+    async with client_for(app) as client:
+        response = await client.post('/', json=send_message_request())
+    assert response.status_code == 200
+    assert A2A_EXTENSIONS_HEADER not in response.headers
+    assert worker.seen == [[]]
+
+
+async def test_a_required_extension_left_inactive_is_refused_before_a_task_exists():
+    app, worker = build_app([AgentExtension(uri=CITATIONS, required=True), AgentExtension(uri=TRACE)])
+    async with client_for(app) as client:
+        response = await client.post('/', json=send_message_request(), headers={A2A_EXTENSIONS_HEADER: TRACE})
+    assert response.status_code == 200
+    body = response.json()
+    assert body['error'] == {
+        'code': -32600,
+        'message': 'Request payload validation error',
+        'data': {'missing_required_extensions': [CITATIONS]},
+    }
+    assert response.headers[A2A_EXTENSIONS_HEADER] == TRACE
+    assert worker.seen == []
+
+
+async def test_a_stream_echoes_the_activated_extensions():
+    app, worker = build_app([AgentExtension(uri=TRACE)])
+    async with client_for(app) as client:
+        async with client.stream(
+            'POST', '/', json=send_message_request('message/stream'), headers={A2A_EXTENSIONS_HEADER: TRACE}
+        ) as response:
+            assert response.status_code == 200
+            assert response.headers[A2A_EXTENSIONS_HEADER] == TRACE
+            events = [line async for line in response.aiter_lines() if line.startswith('data: ')]
+    assert events, 'the stream sent nothing'
+    assert worker.seen == [[TRACE]]
+
+
+async def test_tasks_get_is_not_gated_by_required_extensions():
+    app, _ = build_app([AgentExtension(uri=CITATIONS, required=True)])
+    async with client_for(app) as client:
+        response = await client.post(
+            '/', json={'jsonrpc': '2.0', 'id': 1, 'method': 'tasks/get', 'params': {'id': 'nope'}}
+        )
+    assert response.json()['error']['code'] == -32001
+
+
+def test_agent_to_a2a_forwards_extensions():
+    pytest.importorskip('pydantic_ai', reason='pydantic-ai-slim required (Python 3.10+)')
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from fasta2a.pydantic_ai import agent_to_a2a
+
+    app = agent_to_a2a(Agent(TestModel()), extensions=[AgentExtension(uri=TRACE)])
+    assert app.extensions == [AgentExtension(uri=TRACE)]


### PR DESCRIPTION
## What

Adds [A2A extensions](https://a2a-protocol.org/latest/topics/extensions/) to FastA2A, on top of the event_bus streaming that landed on `main`:

- `FastA2A(extensions=[AgentExtension(...)])` and `agent_to_a2a(..., extensions=...)` declare the extensions the agent supports; the agent card lists them under `capabilities.extensions`.
- Per request, the `A2A-Extensions` header is parsed, intersected with the supported set (in the client's order), and echoed back on the response — for `message/send`, `message/stream`, `tasks/resubscribe` and the plain JSON-RPC responses alike. A URI the agent never declared is not echoed, which is how the client learns it was ignored.
- The activated list travels in the message `metadata` (`a2a.activated_extensions`) through the `TaskManager` into `TaskSendParams`, so a `Worker` reads what was agreed with `activated_extensions(params)`.
- A `message/send` / `message/stream` that leaves a `required` extension inactive is refused with `-32600` and `data.missing_required_extensions`, before any task is created. Other methods (`tasks/get`, …) are not gated.
- `fasta2a.extensions` holds the small vocabulary (`parse_extensions_header`, `select_activated_extensions`, `missing_required_extensions`, …); `AgentExtension`, `A2A_EXTENSIONS_HEADER` and `activated_extensions` are exported from the package root.

## Why a new PR

This replaces #44, which was written against the pre-event_bus streaming implementation and had diverged from `main`. The review notes there are addressed here: the activated extensions are consumed downstream (they reach the worker), `AgentCapabilities.extensions` is the one already on `main` rather than a duplicate, and no streaming-flag changes are bundled in.

## Tests and docs

- `tests/test_extensions.py`: header parsing, activation order, card declaration, header echo on send and stream, worker visibility, required-extension refusal, `tasks/get` not gated, `agent_to_a2a` passthrough.
- README: an *Extensions* section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
