### PR TITLE
feat: end a task's stream when its worker is done, and stream the bridge's answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ As you see, it's pretty easy from the point of view of the developer using your 
 > In Pydantic AI 1.x, `Agent.to_a2a()` continues to work but emits a deprecation
 > warning pointing here. It will be removed in Pydantic AI v2.
 
+#### Streaming
+
+`message/stream` answers with server-sent events: the task first, then whatever the `Worker`
+publishes while it runs — `publish_status` for a change of state, `publish_artifact` for a result,
+whole or chunk by chunk with `append=True` — and the stream ends when the task reaches a final
+state. The worker does not have to publish that end: once `run_task` returns, the task's state is
+read back from storage, published, and the stream closed (`completed`, or `failed` if the run
+raised), so a worker that only writes storage still ends its stream properly.
+
+The Pydantic AI bridge publishes `working` when it starts, the model's text as chunks of the
+answer's artifact while it is written, and the whole artifact as the last chunk.
+
 ## Extensions
 
 An [extension](https://a2a-protocol.org/latest/topics/extensions/) is a capability negotiated by URI on top of the

--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ As you see, it's pretty easy from the point of view of the developer using your 
 `message/stream` answers with server-sent events: the task first, then whatever the `Worker`
 publishes while it runs — `publish_status` for a change of state, `publish_artifact` for a result,
 whole or chunk by chunk with `append=True` — and the stream ends when the task reaches a final
-state. The worker does not have to publish that end: once `run_task` returns, the task's state is
-read back from storage, published, and the stream closed (`completed`, or `failed` if the run
-raised), so a worker that only writes storage still ends its stream properly.
+state. The worker does not have to publish that end: once `run_task` or `cancel_task` returns, the
+task's state is read back from storage and, if the task is over (`completed`, `canceled`, `failed`,
+`rejected`) or waiting on the client (`input-required`, `auth-required`), published and the stream
+closed — `failed` when the run raised — so a worker that only writes storage still ends its stream.
+`tasks/resubscribe` on a task in one of those states returns the task and ends at once.
 
 The Pydantic AI bridge publishes `working` when it starts, the model's text as chunks of the
 answer's artifact while it is written, and the whole artifact as the last chunk.

--- a/fasta2a/event_bus.py
+++ b/fasta2a/event_bus.py
@@ -5,7 +5,7 @@ from __future__ import annotations as _annotations
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 import anyio
 import anyio.abc
@@ -74,6 +74,10 @@ class InMemoryEventBus(EventBus):
             except (anyio.BrokenResourceError, anyio.ClosedResourceError):
                 if send_stream in subscribers:
                     subscribers.remove(send_stream)
+                # Closed as well as dropped, so nothing lingers until the subscription exits;
+                # closing what is already broken must not raise either.
+                with suppress(Exception):
+                    await send_stream.aclose()
         if not subscribers:
             self._subscribers.pop(task_id, None)
 

--- a/fasta2a/event_bus.py
+++ b/fasta2a/event_bus.py
@@ -60,9 +60,22 @@ class InMemoryEventBus(EventBus):
             await receive_stream.aclose()
 
     async def emit(self, task_id: str, event: StreamResponse) -> None:
-        """Emit an event to all subscribers for a task."""
-        for send_stream in self._subscribers.get(task_id, []):
-            await send_stream.send(event)
+        """Emit an event to all subscribers for a task.
+
+        A subscriber whose connection is gone is dropped, rather than left to break the worker
+        publishing to it.
+        """
+        subscribers = self._subscribers.get(task_id)
+        if not subscribers:
+            return
+        for send_stream in list(subscribers):
+            try:
+                await send_stream.send(event)
+            except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+                if send_stream in subscribers:
+                    subscribers.remove(send_stream)
+        if not subscribers:
+            self._subscribers.pop(task_id, None)
 
     async def close(self, task_id: str) -> None:
         """Close all subscriber streams for a task, signaling end of SSE."""

--- a/fasta2a/pydantic_ai/_bridge.py
+++ b/fasta2a/pydantic_ai/_bridge.py
@@ -197,15 +197,18 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
         self, task_id: str, context_id: str, artifact_id: str, message_history: list[ModelMessage]
     ) -> tuple[AgentRunResult[WorkerOutputT], bool]:
         streamed = False
-        entered = False
+        # Whether the run got anywhere: an event received, or a stream completed.
+        # A model that cannot stream refuses before either — on entering the
+        # stream in some releases, on its first read in others.
+        progressed = False
         try:
             async with self.agent.iter(message_history=message_history) as run:  # type: ignore
                 async for node in run:
                     if not Agent.is_model_request_node(node):
                         continue
                     async with node.stream(run.ctx) as request_stream:
-                        entered = True
                         async for event in request_stream:
+                            progressed = True
                             delta = _text_delta(event)
                             if delta:
                                 streamed = True
@@ -216,11 +219,12 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
                                     append=True,
                                     last_chunk=False,
                                 )
+                    progressed = True
         except (NotImplementedError, AssertionError) as exc:
             # `Model.request_stream` raises NotImplementedError when a model does
-            # not stream, and FunctionModel asserts; both on entering the first
-            # stream, before a request is made. Anything later is a real error.
-            if entered:
+            # not stream, and FunctionModel asserts — before any request is made.
+            # The same errors once the run has progressed are real ones.
+            if progressed:
                 raise
             raise _CannotStream() from exc
         self._streaming = True

--- a/fasta2a/pydantic_ai/_bridge.py
+++ b/fasta2a/pydantic_ai/_bridge.py
@@ -4,7 +4,7 @@ import base64
 import uuid
 from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Generic, TypeVar
 
@@ -116,11 +116,17 @@ def agent_to_a2a(
     )
 
 
+class _CannotStream(Exception):
+    """The model refused a streamed request before anything had happened."""
+
+
 @dataclass
 class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]):
     """A worker that uses a pydantic-ai agent to execute tasks."""
 
     agent: AbstractAgent[AgentDepsT, WorkerOutputT]
+    _streaming: bool | None = field(default=None, init=False, repr=False)
+    """Whether the agent's model streams: unknown until the first task tries."""
 
     async def run_task(self, params: TaskSendParams) -> None:
         task = await self.storage.load_task(params['id'])
@@ -172,25 +178,52 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
     ) -> tuple[AgentRunResult[WorkerOutputT], bool]:
         """Run the agent, publishing the text it writes as chunks of the answer's artifact.
 
+        The run is streamed when the model streams. A model that does not — a
+        `FunctionModel` without a `stream_function`, say — refuses on its first
+        request, before anything has happened; the run is then done again without
+        streaming, and that is remembered so the next task does not try.
+
         Returns the run's result and whether any text was streamed.
         """
+        if self._streaming is not False:
+            try:
+                return await self._run_agent_streaming(task_id, context_id, artifact_id, message_history)
+            except _CannotStream:
+                self._streaming = False
+        result = await self.agent.run(message_history=message_history)  # type: ignore
+        return result, False
+
+    async def _run_agent_streaming(
+        self, task_id: str, context_id: str, artifact_id: str, message_history: list[ModelMessage]
+    ) -> tuple[AgentRunResult[WorkerOutputT], bool]:
         streamed = False
-        async with self.agent.iter(message_history=message_history) as run:  # type: ignore
-            async for node in run:
-                if not Agent.is_model_request_node(node):
-                    continue
-                async with node.stream(run.ctx) as request_stream:
-                    async for event in request_stream:
-                        delta = _text_delta(event)
-                        if delta:
-                            streamed = True
-                            await self.publish_artifact(
-                                task_id,
-                                context_id,
-                                Artifact(artifact_id=artifact_id, parts=[Part(text=delta)]),
-                                append=True,
-                                last_chunk=False,
-                            )
+        entered = False
+        try:
+            async with self.agent.iter(message_history=message_history) as run:  # type: ignore
+                async for node in run:
+                    if not Agent.is_model_request_node(node):
+                        continue
+                    async with node.stream(run.ctx) as request_stream:
+                        entered = True
+                        async for event in request_stream:
+                            delta = _text_delta(event)
+                            if delta:
+                                streamed = True
+                                await self.publish_artifact(
+                                    task_id,
+                                    context_id,
+                                    Artifact(artifact_id=artifact_id, parts=[Part(text=delta)]),
+                                    append=True,
+                                    last_chunk=False,
+                                )
+        except (NotImplementedError, AssertionError) as exc:
+            # `Model.request_stream` raises NotImplementedError when a model does
+            # not stream, and FunctionModel asserts; both on entering the first
+            # stream, before a request is made. Anything later is a real error.
+            if entered:
+                raise
+            raise _CannotStream() from exc
+        self._streaming = True
         result = run.result
         if result is None:  # pragma: no cover - the run has been iterated to its end
             raise RuntimeError('The agent run ended without a result')

--- a/fasta2a/pydantic_ai/_bridge.py
+++ b/fasta2a/pydantic_ai/_bridge.py
@@ -12,6 +12,7 @@ from pydantic import TypeAdapter
 
 try:
     from pydantic_ai import (
+        Agent,
         AudioUrl,
         BinaryContent,
         DocumentUrl,
@@ -21,14 +22,18 @@ try:
         ModelRequestPart,
         ModelResponse,
         ModelResponsePart,
+        PartDeltaEvent,
+        PartStartEvent,
         TextPart,
+        TextPartDelta,
         ThinkingPart,
         ToolCallPart,
         UserPromptPart,
         VideoUrl,
     )
     from pydantic_ai._run_context import AgentDepsT
-    from pydantic_ai.agent import AbstractAgent
+    from pydantic_ai.agent import AbstractAgent, AgentRunResult
+    from pydantic_ai.messages import AgentStreamEvent
     from pydantic_ai.output import OutputDataT
 except ImportError as _e:
     raise ImportError(
@@ -125,15 +130,21 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
         if task['status']['state'] != 'submitted':
             raise ValueError(f'Task {params["id"]} has already been processed (state: {task["status"]["state"]})')
 
-        await self.storage.update_task(task['id'], state='working')
+        task_id = task['id']
+        context_id = task['context_id']
+        await self.storage.update_task(task_id, state='working')
+        await self.publish_status(task_id, context_id, 'working')
 
-        message_history = await self.storage.load_context(task['context_id']) or []
+        message_history = await self.storage.load_context(context_id) or []
         message_history.extend(self.build_message_history(task.get('history', [])))
 
+        # The answer streams as chunks of one artifact while the model writes it; the whole
+        # artifact follows as the last chunk, under the same id.
+        artifact_id = str(uuid.uuid4())
         try:
-            result = await self.agent.run(message_history=message_history)  # type: ignore
+            result, streamed = await self._run_agent(task_id, context_id, artifact_id, message_history)
 
-            await self.storage.update_context(task['context_id'], result.all_messages())
+            await self.storage.update_context(context_id, result.all_messages())
 
             a2a_messages: list[Message] = []
             for message in result.new_messages():
@@ -144,13 +155,46 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
                     a2a_messages.append(Message(role='agent', parts=a2a_parts, message_id=str(uuid.uuid4())))
 
             artifacts = self.build_artifacts(result.output)
+            if streamed and artifacts:
+                artifacts[0]['artifact_id'] = artifact_id
         except Exception:
-            await self.storage.update_task(task['id'], state='failed')
+            await self.storage.update_task(task_id, state='failed')
             raise
         else:
             await self.storage.update_task(
-                task['id'], state='completed', new_artifacts=artifacts, new_messages=a2a_messages
+                task_id, state='completed', new_artifacts=artifacts, new_messages=a2a_messages
             )
+            for artifact in artifacts:
+                await self.publish_artifact(task_id, context_id, artifact)
+
+    async def _run_agent(
+        self, task_id: str, context_id: str, artifact_id: str, message_history: list[ModelMessage]
+    ) -> tuple[AgentRunResult[WorkerOutputT], bool]:
+        """Run the agent, publishing the text it writes as chunks of the answer's artifact.
+
+        Returns the run's result and whether any text was streamed.
+        """
+        streamed = False
+        async with self.agent.iter(message_history=message_history) as run:  # type: ignore
+            async for node in run:
+                if not Agent.is_model_request_node(node):
+                    continue
+                async with node.stream(run.ctx) as request_stream:
+                    async for event in request_stream:
+                        delta = _text_delta(event)
+                        if delta:
+                            streamed = True
+                            await self.publish_artifact(
+                                task_id,
+                                context_id,
+                                Artifact(artifact_id=artifact_id, parts=[Part(text=delta)]),
+                                append=True,
+                                last_chunk=False,
+                            )
+        result = run.result
+        if result is None:  # pragma: no cover - the run has been iterated to its end
+            raise RuntimeError('The agent run ended without a result')
+        return result, streamed
 
     async def cancel_task(self, params: TaskIdParams) -> None:
         pass
@@ -235,3 +279,12 @@ class AgentWorker(Worker[list[ModelMessage]], Generic[WorkerOutputT, AgentDepsT]
             elif isinstance(part, ToolCallPart):
                 pass
         return a2a_parts
+
+
+def _text_delta(event: AgentStreamEvent) -> str | None:
+    """The text a model stream event adds to the answer, if any."""
+    if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+        return event.part.content or None
+    if isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+        return event.delta.content_delta or None
+    return None

--- a/fasta2a/schema.py
+++ b/fasta2a/schema.py
@@ -503,6 +503,15 @@ TaskState: TypeAlias = Literal[
 ]
 """The possible states of a task."""
 
+STREAM_ENDING_STATES: frozenset[str] = frozenset(
+    {'completed', 'canceled', 'failed', 'rejected', 'input-required', 'auth-required'}
+)
+"""The states at which a task's stream ends: the task is over, or it is waiting on the client.
+
+The status update that carries one of these is the last event of a `message/stream`, and
+`tasks/resubscribe` on such a task has nothing to wait for.
+"""
+
 
 @pydantic.with_config({'alias_generator': to_camel})
 class TaskStatus(TypedDict):

--- a/fasta2a/task_manager.py
+++ b/fasta2a/task_manager.py
@@ -68,6 +68,7 @@ from typing import Any
 
 from .broker import Broker
 from .schema import (
+    STREAM_ENDING_STATES,
     CancelTaskRequest,
     CancelTaskResponse,
     DeleteTaskPushNotificationConfigRequest,
@@ -220,9 +221,8 @@ class TaskManager:
         initial_response = StreamMessageResponse(jsonrpc='2.0', id=request_id, result=StreamResponse(task=task))
         yield self._format_sse_event(initial_response)
 
-        # If task is already in a terminal state, no need to subscribe
-        terminal_states = {'completed', 'canceled', 'failed', 'rejected'}
-        if task['status']['state'] in terminal_states:
+        # A task at one of these states has ended its stream: nothing more to wait for.
+        if task['status']['state'] in STREAM_ENDING_STATES:
             return
 
         async with self.broker.event_bus.subscribe(task_id) as receive_stream:

--- a/fasta2a/worker.py
+++ b/fasta2a/worker.py
@@ -10,6 +10,7 @@ import anyio
 from opentelemetry.trace import get_tracer, use_span
 from typing_extensions import assert_never
 
+from .schema import STREAM_ENDING_STATES
 from .storage import ContextT, Storage
 
 if TYPE_CHECKING:
@@ -17,11 +18,6 @@ if TYPE_CHECKING:
     from .schema import Artifact, Message, TaskIdParams, TaskSendParams, TaskState
 
 tracer = get_tracer(__name__)
-
-STREAM_ENDING_STATES: frozenset[str] = frozenset(
-    {'completed', 'canceled', 'failed', 'rejected', 'input-required', 'auth-required'}
-)
-"""The states a task's stream ends at: the task is over, or it is waiting on the client."""
 
 
 @dataclass

--- a/fasta2a/worker.py
+++ b/fasta2a/worker.py
@@ -14,14 +14,26 @@ from .storage import ContextT, Storage
 
 if TYPE_CHECKING:
     from .broker import Broker, TaskOperation
-    from .schema import Artifact, Message, TaskIdParams, TaskSendParams
+    from .schema import Artifact, Message, TaskIdParams, TaskSendParams, TaskState
 
 tracer = get_tracer(__name__)
+
+STREAM_ENDING_STATES: frozenset[str] = frozenset(
+    {'completed', 'canceled', 'failed', 'rejected', 'input-required', 'auth-required'}
+)
+"""The states a task's stream ends at: the task is over, or it is waiting on the client."""
 
 
 @dataclass
 class Worker(ABC, Generic[ContextT]):
-    """A worker is responsible for executing tasks."""
+    """A worker is responsible for executing tasks.
+
+    While a task runs, a worker reports on the broker's event bus with `publish_status` and
+    `publish_artifact`, and a `message/stream` relays what it publishes as it comes. It does not
+    have to report the end: once an operation returns, the task's final state is read back from
+    storage, published, and the stream closed — and when `run_task` raises, the task is marked
+    failed and the same is done — so a worker that only writes storage still ends its stream.
+    """
 
     broker: Broker
     storage: Storage[ContextT]
@@ -42,6 +54,7 @@ class Worker(ABC, Generic[ContextT]):
             await self._handle_task_operation(task_operation)
 
     async def _handle_task_operation(self, task_operation: TaskOperation) -> None:
+        task_id = task_operation['params']['id']
         try:
             with use_span(task_operation['_current_span']):
                 with tracer.start_as_current_span(
@@ -54,21 +67,61 @@ class Worker(ABC, Generic[ContextT]):
                     else:
                         assert_never(task_operation)
         except Exception:
-            task_id = task_operation['params']['id']
             task = await self.storage.update_task(task_id, state='failed')
-            from .schema import StreamResponse, TaskStatus, TaskStatusUpdateEvent
+            await self._end_stream(task_id, task['context_id'], 'failed')
+        else:
+            await self._publish_final_state(task_id)
 
-            await self.broker.event_bus.emit(
-                task_id,
-                StreamResponse(
-                    status_update=TaskStatusUpdateEvent(
-                        task_id=task_id,
-                        context_id=task['context_id'],
-                        status=TaskStatus(state='failed'),
-                    )
-                ),
-            )
-            await self.broker.event_bus.close(task_id)
+    async def publish_status(
+        self, task_id: str, context_id: str, state: TaskState, message: Message | None = None
+    ) -> None:
+        """Tell the task's stream that its state changed, with a message for the client if there is one."""
+        from .schema import StreamResponse, TaskStatus, TaskStatusUpdateEvent
+
+        status = TaskStatus(state=state)
+        if message is not None:
+            status['message'] = message
+        await self.broker.event_bus.emit(
+            task_id,
+            StreamResponse(status_update=TaskStatusUpdateEvent(task_id=task_id, context_id=context_id, status=status)),
+        )
+
+    async def publish_artifact(
+        self, task_id: str, context_id: str, artifact: Artifact, *, append: bool = False, last_chunk: bool = True
+    ) -> None:
+        """Send an artifact, or a chunk of one, to the task's stream.
+
+        A chunk is ``append=True`` and, until the last one, ``last_chunk=False``; the client joins
+        the chunks that share an ``artifact_id``.
+        """
+        from .schema import StreamResponse, TaskArtifactUpdateEvent
+
+        await self.broker.event_bus.emit(
+            task_id,
+            StreamResponse(
+                artifact_update=TaskArtifactUpdateEvent(
+                    task_id=task_id, context_id=context_id, artifact=artifact, append=append, last_chunk=last_chunk
+                )
+            ),
+        )
+
+    async def _publish_final_state(self, task_id: str) -> None:
+        """End the task's stream if the task is over, or waiting on the client.
+
+        The state is read back from storage, so it is whatever the worker left there. A worker
+        that already published it and closed the stream has no subscribers left, and this is a
+        no-op.
+        """
+        task = await self.storage.load_task(task_id)
+        if task is None:
+            return
+        state = task['status']['state']
+        if state in STREAM_ENDING_STATES:
+            await self._end_stream(task_id, task['context_id'], state)
+
+    async def _end_stream(self, task_id: str, context_id: str, state: TaskState) -> None:
+        await self.publish_status(task_id, context_id, state)
+        await self.broker.event_bus.close(task_id)
 
     @abstractmethod
     async def run_task(self, params: TaskSendParams) -> None: ...

--- a/tests/test_pydantic_ai_streaming.py
+++ b/tests/test_pydantic_ai_streaming.py
@@ -5,13 +5,15 @@ from __future__ import annotations as _annotations
 import sys
 import uuid
 
+import anyio
 import httpx
 import pytest
 from asgi_lifespan import LifespanManager
 
 pytest.importorskip('pydantic_ai', reason='pydantic-ai-slim required (Python 3.10+)')
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from fasta2a.client import A2AClient
@@ -55,3 +57,27 @@ async def test_stream_message_streams_the_answer_and_ends():
     assert final.get('last_chunk') is True
     assert [part.get('text') for part in final['artifact']['parts']] == ['hello streaming world']
     assert {chunk['artifact']['artifact_id'] for chunk in chunks} == {final['artifact']['artifact_id']}
+
+
+def _plain_answer(_: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content='plain answer')])
+
+
+async def test_a_model_that_cannot_stream_still_answers_and_the_stream_ends():
+    # A FunctionModel without a `stream_function` refuses streamed requests.
+    app = agent_to_a2a(Agent(FunctionModel(_plain_answer)))
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            client = A2AClient(http_client=http_client)
+            message = Message(role='user', parts=[Part(text='hi')], message_id=str(uuid.uuid4()))
+            with anyio.fail_after(10):
+                events: list[StreamResponse] = [
+                    response['result'] async for response in client.stream_message(message) if 'result' in response
+                ]
+
+    states = [event['status_update']['status']['state'] for event in events if 'status_update' in event]
+    assert states == ['working', 'completed']
+    chunks = [event['artifact_update'] for event in events if 'artifact_update' in event]
+    assert [chunk.get('append') for chunk in chunks] == [False]
+    assert [part.get('text') for part in chunks[0]['artifact']['parts']] == ['plain answer']

--- a/tests/test_pydantic_ai_streaming.py
+++ b/tests/test_pydantic_ai_streaming.py
@@ -1,0 +1,57 @@
+"""The pydantic-ai bridge streams: the answer arrives as artifact chunks, and the stream ends."""
+
+from __future__ import annotations as _annotations
+
+import sys
+import uuid
+
+import httpx
+import pytest
+from asgi_lifespan import LifespanManager
+
+pytest.importorskip('pydantic_ai', reason='pydantic-ai-slim required (Python 3.10+)')
+
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from fasta2a.client import A2AClient
+from fasta2a.pydantic_ai import agent_to_a2a
+from fasta2a.schema import Message, Part, StreamResponse
+
+pytestmark = [
+    pytest.mark.skipif(sys.version_info < (3, 10), reason='pydantic-ai-slim requires 3.10+'),
+    pytest.mark.anyio,
+]
+
+
+async def test_stream_message_streams_the_answer_and_ends():
+    app = agent_to_a2a(Agent(TestModel(custom_output_text='hello streaming world')))
+    async with LifespanManager(app):
+        transport = httpx.ASGITransport(app)
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            client = A2AClient(http_client=http_client)
+            message = Message(role='user', parts=[Part(text='hi')], message_id=str(uuid.uuid4()))
+            events: list[StreamResponse] = [
+                response['result'] async for response in client.stream_message(message) if 'result' in response
+            ]
+
+    # The stream ended on its own: the task first, the final state last.
+    assert 'task' in events[0]
+    assert events[0]['task']['status']['state'] == 'submitted'
+    states = [event['status_update']['status']['state'] for event in events if 'status_update' in event]
+    assert states == ['working', 'completed']
+    assert 'status_update' in events[-1]
+
+    # The answer streamed as chunks of one artifact, then came whole as the last chunk of it.
+    chunks = [event['artifact_update'] for event in events if 'artifact_update' in event]
+    streamed = [chunk for chunk in chunks if chunk.get('append')]
+    assert streamed, 'the answer was not streamed'
+    assert all(chunk.get('last_chunk') is False for chunk in streamed)
+    assert ''.join(part.get('text', '') for chunk in streamed for part in chunk['artifact']['parts']) == (
+        'hello streaming world'
+    )
+    final = chunks[-1]
+    assert final.get('append') is False
+    assert final.get('last_chunk') is True
+    assert [part.get('text') for part in final['artifact']['parts']] == ['hello streaming world']
+    assert {chunk['artifact']['artifact_id'] for chunk in chunks} == {final['artifact']['artifact_id']}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -77,11 +77,36 @@ class EchoWorker(Worker[Any]):
         return []
 
 
+class SilentWorker(Worker[Any]):
+    """A worker that writes storage and says nothing on the event bus."""
+
+    async def run_task(self, params: TaskSendParams) -> None:
+        await self.storage.update_task(params['id'], state='working')
+        artifact = Artifact(artifact_id=str(uuid.uuid4()), parts=params['message']['parts'])
+        await self.storage.update_task(params['id'], state='completed', new_artifacts=[artifact])
+
+    async def cancel_task(self, params: Any) -> None:
+        pass
+
+    def build_message_history(self, history: list[Message]) -> list[Any]:
+        return []
+
+    def build_artifacts(self, result: Any) -> list[Artifact]:
+        return []
+
+
+class FailingWorker(SilentWorker):
+    """A worker whose task blows up."""
+
+    async def run_task(self, params: TaskSendParams) -> None:
+        raise RuntimeError('no can do')
+
+
 @asynccontextmanager
-async def create_streaming_app() -> AsyncIterator[httpx.AsyncClient]:
+async def create_streaming_app(worker_type: type[Worker[Any]] = EchoWorker) -> AsyncIterator[httpx.AsyncClient]:
     broker = InMemoryBroker()
     storage = InMemoryStorage()
-    worker = EchoWorker(broker=broker, storage=storage)
+    worker = worker_type(broker=broker, storage=storage)
 
     app = FastA2A(storage=storage, broker=broker)
 
@@ -129,3 +154,38 @@ async def test_stream_message():
         # Third event: completed status update
         assert 'status_update' in events[2]
         assert events[2]['status_update']['status']['state'] == 'completed'
+
+
+async def test_stream_ends_when_the_worker_only_writes_storage():
+    async with create_streaming_app(SilentWorker) as http_client:
+        client = A2AClient(http_client=http_client)
+        client.http_client.base_url = 'http://testclient'
+
+        message = Message(role='user', parts=[Part(text='Hello, world!')], message_id=str(uuid.uuid4()))
+        events: list[StreamResponse] = []
+        async for response in client.stream_message(message):
+            if 'result' in response:
+                events.append(response['result'])
+
+    # The task, then its final state read back from storage — and the stream is over.
+    assert len(events) == 2
+    assert 'task' in events[0]
+    assert events[0]['task']['status']['state'] == 'submitted'
+    assert 'status_update' in events[1]
+    assert events[1]['status_update']['status']['state'] == 'completed'
+
+
+async def test_stream_ends_failed_when_the_worker_raises():
+    async with create_streaming_app(FailingWorker) as http_client:
+        client = A2AClient(http_client=http_client)
+        client.http_client.base_url = 'http://testclient'
+
+        message = Message(role='user', parts=[Part(text='Hello, world!')], message_id=str(uuid.uuid4()))
+        events: list[StreamResponse] = []
+        async for response in client.stream_message(message):
+            if 'result' in response:
+                events.append(response['result'])
+
+    assert len(events) == 2
+    assert 'status_update' in events[1]
+    assert events[1]['status_update']['status']['state'] == 'failed'

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,10 +1,12 @@
 from __future__ import annotations as _annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
+import anyio
 import httpx
 import pytest
 from asgi_lifespan import LifespanManager
@@ -93,6 +95,13 @@ class SilentWorker(Worker[Any]):
 
     def build_artifacts(self, result: Any) -> list[Artifact]:
         return []
+
+
+class InputRequiredWorker(SilentWorker):
+    """A worker that stops to ask the client something."""
+
+    async def run_task(self, params: TaskSendParams) -> None:
+        await self.storage.update_task(params['id'], state='input-required')
 
 
 class FailingWorker(SilentWorker):
@@ -189,3 +198,33 @@ async def test_stream_ends_failed_when_the_worker_raises():
     assert len(events) == 2
     assert 'status_update' in events[1]
     assert events[1]['status_update']['status']['state'] == 'failed'
+
+
+async def test_a_task_waiting_on_the_client_ends_its_stream_and_resubscribe_returns_at_once():
+    async with create_streaming_app(InputRequiredWorker) as http_client:
+        client = A2AClient(http_client=http_client)
+        client.http_client.base_url = 'http://testclient'
+
+        message = Message(role='user', parts=[Part(text='Hello, world!')], message_id=str(uuid.uuid4()))
+        events: list[StreamResponse] = []
+        async for response in client.stream_message(message):
+            if 'result' in response:
+                events.append(response['result'])
+
+        assert len(events) == 2
+        assert 'task' in events[0]
+        assert 'status_update' in events[1]
+        assert events[1]['status_update']['status']['state'] == 'input-required'
+
+        # The worker closed that stream; resubscribing must not wait for events that will not come.
+        resubscribe = {
+            'jsonrpc': '2.0',
+            'id': '2',
+            'method': 'tasks/resubscribe',
+            'params': {'id': events[0]['task']['id']},
+        }
+        with anyio.fail_after(5):
+            async with http_client.stream('POST', '/', json=resubscribe) as response:
+                lines = [line async for line in response.aiter_lines() if line.startswith('data: ')]
+    assert len(lines) == 1
+    assert json.loads(lines[0][6:])['result']['task']['status']['state'] == 'input-required'


### PR DESCRIPTION
## Problem

The SSE plumbing from #51 is on `main` (event bus, `message/stream`, `tasks/resubscribe`), but a stream only ends when the worker publishes a final status and closes the bus itself. A worker that just writes storage never does — and the pydantic-ai bridge's `AgentWorker` is such a worker. Verified against `main` with `agent_to_a2a(Agent(TestModel(...)))`: the task reaches `completed` in storage within a second, while the `message/stream` response has sent nothing and never ends.

## Fix

- **`Worker`** — once `run_task` / `cancel_task` returns, the task's state is read back from storage and, if it is final (`completed`, `canceled`, `failed`, `rejected`) or waiting on the client (`input-required`, `auth-required`), published and the stream closed. The failure path does what it did before. A worker that already published and closed sees no duplicate: nothing is subscribed by then. New `publish_status` / `publish_artifact` helpers give workers a plain way to report progress.
- **`InMemoryEventBus.emit`** — drops a subscriber whose connection is gone (`BrokenResourceError` / `ClosedResourceError`) instead of letting a disconnected SSE client break the worker.
- **pydantic-ai bridge** — publishes `working` when it starts, the model's text as chunks of the answer's artifact while it is written (`append=True`, via `Agent.iter`, available on every pydantic-ai release the bridge supports), and the whole artifact as the last chunk under the same `artifact_id`. With `TestModel(custom_output_text='hello streaming world')` the stream is now: task → working → `'hello '` → `'streaming '` → `'world'` → whole artifact (last chunk) → completed, and ends.

## Tests and docs

- `tests/test_streaming.py`: a worker that only writes storage ends its stream with `completed`; one that raises ends it with `failed`. The existing echo-worker test is unchanged (still exactly three events).
- `tests/test_pydantic_ai_streaming.py`: the bridge streams the answer and ends.
- README: a *Streaming* subsection under Design.

Succeeds the closed #43, on top of the event_bus design rather than beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
